### PR TITLE
nzalchemy dialect using nzpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 <!-- Not always needed, but a scope helps the user understand in a short sentance like below, why this repo exists -->
 ## Scope
 
-nzalchemy runs on top of pyodbc(over nzodbc) as a dialect to bridge Netezza Performance Server and SQLAlchemy applications.
+nzalchemy runs on top of pyodbc(over nzodbc) or nzpy as a dialect to bridge Netezza Performance Server and SQLAlchemy applications.
 
-## Prerequisites
+## Prerequisites for using nzalchemy with pyodbc
 
 **Install pyodbc Python package**
 
@@ -51,6 +51,19 @@ The installation program installs the Netezza ODBC libraries on your system, cre
 
 For further details read here: https://www.ibm.com/support/knowledgecenter/SSULQD_7.2.1/com.ibm.nz.datacon.doc/c_datacon_installing_configuring_odbc_win.html
 
+## Prerequisites for using nzalchemy with nzpy
+**Install nzpy package**
+
+To install nzpy using pip type:
+```shell
+pip install nzpy
+```
+
+To install nzpy using setup.py:
+```shell
+python setup.py install
+```
+
 **Installing Netezza SQLAlchemy**
 
 The Netezza SQLAlchemy package can be installed from the public PyPI repository using pip:
@@ -59,7 +72,7 @@ The Netezza SQLAlchemy package can be installed from the public PyPI repository 
 
 **Connection Parameters**
 
-To connect to Netezza with SQLAlchemy use the following connection string:
+To connect to Netezza with SQLAlchemy using pyodbc use the following connection string:
 
 ```netezza+pyodbc:///?<ODBC connection parameters>```
 
@@ -69,6 +82,26 @@ import urllib
 params= urllib.parse.quote_plus("DRIVER=<path-to-libnzodbc.so>;SERVER=<nz-running-server>;PORT=5480;DATABASE=<dbname>;UID=<usr>;PWD=<password>")
 
 engine = create_engine("netezza+pyodbc:///?odbc_connect=%s" % params,  echo=True)
+```
+
+To connect to Netezza with SQLAlchemy using nzpy use the following connection string:
+
+```netezza+nzpy://username:password@hostname:port/databasename```
+
+For example:
+```
+engine = create_engine("netezza+nzpy://admin:password@localhost:5480/db1")
+```
+
+In order to pass any nzpy connection arguments to nzalchemy use below:
+
+```
+import nzpy
+
+def creator():
+    return nzpy.connect(user="admin", password="password",host='localhost', port=5480, database="db1", securityLevel=0,logOptions=nzpy.LogOptions.Logfile, char_varchar_encoding='utf8')
+
+engine = create_engine("netezza+nzpy://", creator=creator)
 ```
 
 **Feature Support**
@@ -136,6 +169,8 @@ import nzalchemy as nz
 import urllib 
 params= urllib.parse.quote_plus("DRIVER=<path-to-libnzodbc.so>;SERVER=<nz-running-server>;PORT=5480;DATABASE=<dbname>;UID=<usr>;PWD=<password>")
 engine = create_engine("netezza+pyodbc:///?odbc_connect=%s" % params,  echo=True)
+#create engine using nzpy
+#engine = create_engine("netezza+nzpy://<username>:<password>@<nz-running-server>:5480/<dbname>")
 meta = MetaData()
 test = Table(
 'TEST', meta,

--- a/sqlalchemy-netezza/nzalchemy/__init__.py
+++ b/sqlalchemy-netezza/nzalchemy/__init__.py
@@ -84,6 +84,7 @@ from .json import JSONB
 #__version__ = "11.0.0"
 _registry.register(
     "netezza.pyodbc", "nzalchemy.pyodbc", "NetezzaDialect_pyodbc"
+    #"netezza.nzpy", "nzalchemy.nzpy", "NetezzaDialect_nzpy"
 )
 
 __all__ = (

--- a/sqlalchemy-netezza/nzalchemy/__init__.py
+++ b/sqlalchemy-netezza/nzalchemy/__init__.py
@@ -82,10 +82,13 @@ from .json import JSONB
 '''
 
 #__version__ = "11.0.0"
-#_registry.register(
-    #"netezza.pyodbc", "nzalchemy.pyodbc", "NetezzaDialect_pyodbc"
-    #"netezza.nzpy", "nzalchemy.nzpy", "NetezzaDialect_nzpy"
-#)
+
+_registry.register(
+    "netezza.pyodbc", "nzalchemy.pyodbc", "NetezzaDialect_pyodbc"
+)
+_registry.register(
+    "netezza.nzpy", "nzalchemy.nzpy", "NetezzaDialect_nzpy"
+)
 
 __all__ = (
     "BOOLEAN",

--- a/sqlalchemy-netezza/nzalchemy/__init__.py
+++ b/sqlalchemy-netezza/nzalchemy/__init__.py
@@ -82,10 +82,10 @@ from .json import JSONB
 '''
 
 #__version__ = "11.0.0"
-_registry.register(
-    "netezza.pyodbc", "nzalchemy.pyodbc", "NetezzaDialect_pyodbc"
+#_registry.register(
+    #"netezza.pyodbc", "nzalchemy.pyodbc", "NetezzaDialect_pyodbc"
     #"netezza.nzpy", "nzalchemy.nzpy", "NetezzaDialect_nzpy"
-)
+#)
 
 __all__ = (
     "BOOLEAN",

--- a/sqlalchemy-netezza/nzalchemy/base.py
+++ b/sqlalchemy-netezza/nzalchemy/base.py
@@ -847,7 +847,6 @@ class NetezzaDialect(default.DefaultDialect):
 
     _isolation_lookup = set(
         [
-            "AUTOCOMMIT",
             "SERIALIZABLE",
             "READ UNCOMMITTED",
             "READ COMMITTED",

--- a/sqlalchemy-netezza/nzalchemy/base.py
+++ b/sqlalchemy-netezza/nzalchemy/base.py
@@ -248,13 +248,11 @@ class NCHAR(sqltypes.TypeEngine):
 
 class NVARCHAR(sqltypes.NVARCHAR):
     def __init__(self, length=None, collation=None,
-                 convert_unicode='force',
                  unicode_error=None):
         super(NVARCHAR, self).__init__(
             length,
             collation=collation,
-            convert_unicode=convert_unicode,
-            unicode_error='ignore')
+            )
 
 class FLOAT4(sqltypes.TypeEngine):
     __visit_name__ = "FLOAT4"
@@ -842,13 +840,14 @@ class NetezzaDialect(default.DefaultDialect):
             def connect(conn):
                 log.debug("-->")
                 self.set_isolation_level(conn, self.isolation_level)
-                conn.setencoding(encoding='utf-8')
+                #conn.setencoding(encoding='utf-8')
             return connect
         else:
             return None
 
     _isolation_lookup = set(
         [
+            "AUTOCOMMIT",
             "SERIALIZABLE",
             "READ UNCOMMITTED",
             "READ COMMITTED",
@@ -1137,11 +1136,11 @@ class NetezzaDialect(default.DefaultDialect):
         table_oid = self.get_table_oid(
             connection, table_name, schema, info_cache=kw.get("info_cache")
         )
-        PK_SQL = "select attname from _v_relation_keydata where objid = :table_oid and contype = 'p';"
+        PK_SQL = "select attname from _v_relation_keydata where objid = :table_oid and contype = 'p'"
         t = sql.text(PK_SQL).columns(attname=sqltypes.Unicode)
         c = connection.execute(t, table_oid=table_oid)
         cols = [r[0] for r in c.fetchall()]
-        PK_CONS_SQL = "select constraintname from _v_relation_keydata where objid = :table_oid and contype = 'p';"
+        PK_CONS_SQL = "select constraintname from _v_relation_keydata where objid = :table_oid and contype = 'p'"
         t = sql.text(PK_CONS_SQL).columns(constraintname=sqltypes.Unicode)
         c = connection.execute(t, table_oid=table_oid)
         name = c.scalar()
@@ -1166,7 +1165,7 @@ class NetezzaDialect(default.DefaultDialect):
                 schema=self.denormalize_name(schema)
 
 
-        FK_SQL = "select constraintname, attname,pkschema,pkrelation,pkattname from _v_relation_keydata where objid = :table_oid and contype = 'f' and schema = :schemaname;"     
+        FK_SQL = "select constraintname, attname,pkschema,pkrelation,pkattname from _v_relation_keydata where objid = :table_oid and contype = 'f' and schema = :schemaname"     
         c = connection.execute(
             sql.text(FK_SQL
             ).columns(table_oid=sqltypes.Unicode), 
@@ -1207,7 +1206,7 @@ class NetezzaDialect(default.DefaultDialect):
         table_oid = self.get_table_oid(
             connection, table_name, schema, info_cache=kw.get("info_cache")
         )
-        UNIQUE_SQL = "select constraintname as name, attname as col_name, conseq as col_num from _v_relation_keydata where objid = :table_oid and contype = 'u' order by conseq ASC;"
+        UNIQUE_SQL = "select constraintname as name, attname as col_name, conseq as col_num from _v_relation_keydata where objid = :table_oid and contype = 'u' order by conseq ASC"
         t = sql.text(UNIQUE_SQL).columns(col_name=sqltypes.Unicode)
         c = connection.execute(t, table_oid=table_oid)
         uniques = defaultdict(lambda: defaultdict(dict))

--- a/sqlalchemy-netezza/nzalchemy/nzpy.py
+++ b/sqlalchemy-netezza/nzalchemy/nzpy.py
@@ -10,8 +10,10 @@ class _netezzaNumeric_nzpy(sqltypes.Numeric):
         if self.asdecimal:
             if coltype == 701:
                 return processors.to_decimal_processor_factory( decimal.Decimal, self._effective_decimal_return_scale )
-            if coltype == 1700:
-                return sqltypes.Numeric.result_processor(self, dialect, coltype)
+            elif coltype == 1700:
+                return decimal.Decimal
+            else:
+                return 
         else:
             return processors.to_float
 

--- a/sqlalchemy-netezza/nzalchemy/nzpy.py
+++ b/sqlalchemy-netezza/nzalchemy/nzpy.py
@@ -61,5 +61,18 @@ class NetezzaDialect_nzpy(NetezzaDialect):
         if hasattr(connection, "connection"):
             connection = connection.connection
             connection.autocommit = False
+    
+    def set_isolation_level(self, connection, level):
+        level = level.replace("_", " ")
+        # adjust for ConnectionFairy possibly being present
+        if hasattr(connection, "connection"):
+            connection = connection.connection
+
+        if level == "AUTOCOMMIT":
+            connection.autocommit = True
+        else:
+            cursor = connection.cursor()
+            cursor.execute("BEGIN")
+            cursor.close
 
 dialect = NetezzaDialect_nzpy

--- a/sqlalchemy-netezza/nzalchemy/nzpy.py
+++ b/sqlalchemy-netezza/nzalchemy/nzpy.py
@@ -1,0 +1,63 @@
+from sqlalchemy import processors
+from .base import NetezzaExecutionContext, NetezzaDialect, log
+from sqlalchemy import types as sqltypes, util
+import decimal
+from .base import DATETIME
+import pdb
+
+class _netezzaNumeric_nzpy(sqltypes.Numeric):
+    def result_processor(self, dialect, coltype):
+        if self.asdecimal:
+            if coltype == 701:
+                return processors.to_decimal_processor_factory( decimal.Decimal, self._effective_decimal_return_scale )
+            if coltype == 1700:
+                return sqltypes.Numeric.result_processor(self, dialect, coltype)
+        else:
+            return processors.to_float
+
+class _netezzaTimestamp_nzpy(sqltypes.TIMESTAMP):
+    def result_processor(self, dialect, coltype):
+        return processors.str_to_datetime
+
+class _netezzaDateTime_nzpy(sqltypes.DateTime):
+    def result_processor(self, dialect, coltype):
+        return processors.str_to_datetime
+
+class _netezzaDate_nzpy(sqltypes.Date):
+    def result_processor(self, dialect, coltype):
+        return processors.str_to_date
+
+class _netezzaTime_nzpy(sqltypes.Time):
+    def result_processor(self, dialect, coltype):
+        return processors.str_to_time
+
+class NetezzaExecutionContext_nzpy(NetezzaExecutionContext):
+    pass
+
+class NetezzaDialect_nzpy(NetezzaDialect):
+    execution_ctx_cls = NetezzaExecutionContext_nzpy
+    colspecs = util.update_copy(
+        NetezzaDialect.colspecs,
+        {
+            sqltypes.Numeric: _netezzaNumeric_nzpy,
+            sqltypes.TIMESTAMP: _netezzaTimestamp_nzpy,
+            sqltypes.Date: _netezzaDate_nzpy, 
+            sqltypes.Time: _netezzaTime_nzpy,
+            sqltypes.DateTime: _netezzaDateTime_nzpy
+        }
+    )
+    @classmethod
+    def dbapi(cls):
+        return __import__("nzpy")
+    
+    def create_connect_args(self, url):
+        opts = url.translate_connect_args(username="user")
+        opts.update(url.query)
+        return ([], opts)
+
+    def do_begin(self,connection):
+        if hasattr(connection, "connection"):
+            connection = connection.connection
+            connection.autocommit = False
+
+dialect = NetezzaDialect_nzpy

--- a/sqlalchemy-netezza/nzalchemy/nzpy.py
+++ b/sqlalchemy-netezza/nzalchemy/nzpy.py
@@ -3,7 +3,6 @@ from .base import NetezzaExecutionContext, NetezzaDialect, log
 from sqlalchemy import types as sqltypes, util
 import decimal
 from .base import DATETIME
-import pdb
 
 class _netezzaNumeric_nzpy(sqltypes.Numeric):
     def result_processor(self, dialect, coltype):

--- a/sqlalchemy-netezza/setup.cfg
+++ b/sqlalchemy-netezza/setup.cfg
@@ -13,7 +13,9 @@ profile_file=test/profiles.txt
 #default=netezza+pyodbc://172.16.34.147/TESTODBC?;PORT=5480;UID=admin;PWD=password;DRIVER=/nzscratch/spawar72/SQLAlchemy/ODBC/lib64/libnzodbc.so 
 
 #UPPERCASE
-default=netezza+pyodbc://172.16.34.153/TESTODBC2?;PORT=5480;UID=admin;PWD=password;DRIVER=/nzscratch/spawar72/SQLAlchemy/ODBC/lib64/libnzodbc.so 
+#default=netezza+pyodbc://localhost/DB1?;PORT=5480;UID=admin;PWD=password;DRIVER=/nzscratch/client/linux64/lib64/libnzodbc.so
+
+default=netezza+nzpy://admin:password@localhost:5480/db1
 
 sqlite=sqlite:///:memory:
 

--- a/sqlalchemy-netezza/setup.py
+++ b/sqlalchemy-netezza/setup.py
@@ -39,7 +39,7 @@ setup(
     },
     packages=find_packages(include=["nzalchemy"]),
     include_package_data=True,
-    install_requires=["SQLAlchemy", "pyodbc>=4.0.27","nzpy"],
+    install_requires=["SQLAlchemy<=1.3.24", "pyodbc>=4.0.27","nzpy"],
     zip_safe=False,
     entry_points={
         "sqlalchemy.dialects": [

--- a/sqlalchemy-netezza/setup.py
+++ b/sqlalchemy-netezza/setup.py
@@ -39,11 +39,12 @@ setup(
     },
     packages=find_packages(include=["nzalchemy"]),
     include_package_data=True,
-    install_requires=["SQLAlchemy", "pyodbc>=4.0.27"],
+    install_requires=["SQLAlchemy", "pyodbc>=4.0.27","nzpy"],
     zip_safe=False,
     entry_points={
         "sqlalchemy.dialects": [
             "netezza.pyodbc = nzalchemy.pyodbc:NetezzaDialect_pyodbc",
+            "netezza.nzpy = nzalchemy.nzpy:NetezzaDialect_nzpy"
         ]
     },
 )

--- a/sqlalchemy-netezza/test/test_suite.py
+++ b/sqlalchemy-netezza/test/test_suite.py
@@ -50,10 +50,6 @@ class QuotedNameArgumentTest(_QuotedNameArgumentTest):
         return
 
     @pytest.mark.skip()
-    def quote_fixtures(cls):
-        return
-
-    @pytest.mark.skip()
     def test_get_table_options(cls):
         return
 

--- a/sqlalchemy-netezza/test/test_suite.py
+++ b/sqlalchemy-netezza/test/test_suite.py
@@ -37,11 +37,57 @@ from sqlalchemy.testing.suite import (
     TableDDLTest as _TableDDLTest,
     IntegerTest as _IntegerTest,
     ComponentReflectionTest as _ComponentReflectionTest,
+    CompositeKeyReflectionTest as _CompositeKeyReflectionTest,
     DateHistoricTest as _DateHistoricTest,
     DateTimeHistoricTest as _DateTimeHistoricTest,
     TimestampMicrosecondsTest as _TimestampMicrosecondsTest,
+    QuotedNameArgumentTest as _QuotedNameArgumentTest,
 )
 
+class QuotedNameArgumentTest(_QuotedNameArgumentTest):
+    @pytest.mark.skip()
+    def quote_fixtures(cls):
+        return
+
+    @pytest.mark.skip()
+    def quote_fixtures(cls):
+        return
+
+    @pytest.mark.skip()
+    def test_get_table_options(cls):
+        return
+
+    @pytest.mark.skip()
+    def test_get_view_definition(cls):
+        return
+
+    @pytest.mark.skip()
+    def test_get_columns(cls):
+        return
+
+    @pytest.mark.skip()
+    def test_get_pk_constraint(cls):
+        return
+
+    @pytest.mark.skip()
+    def test_get_foreign_keys(cls):
+        return
+
+    @pytest.mark.skip()
+    def test_get_indexes(cls):
+        return
+
+    @pytest.mark.skip()
+    def test_get_unique_constraints(cls):
+        return 
+
+    @pytest.mark.skip()
+    def test_get_table_comment(cls):
+        return
+
+    @pytest.mark.skip()
+    def test_get_check_constraints(cls):
+        return
 
 class DateHistoricTest(_DateHistoricTest): 
        
@@ -68,7 +114,17 @@ class DateTimeHistoricTest(_DateTimeHistoricTest):
             ),
             Column("date_data", cls.datatype),
         )    
-        
+
+class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
+
+    @pytest.mark.skip()
+    def test_fk_column_order(self):
+        return
+
+    @pytest.mark.skip()
+    def test_pk_column_order(self):
+        return
+
 class ComponentReflectionTest(_ComponentReflectionTest): 
 
     @classmethod


### PR DESCRIPTION
JIRA: https://github.com/IBM/nzalchemy/issues/3

Problem: Support nzalchemy with nzpy

Solution: Added new file nzpy.py in the repo.
To run nzalchemy with nzpy you need to provide nzpy connection args in setup.cfg file

Testing: 

```
[nz@sim-ips26 sqlalchemy-netezza]$ py.test test/test_suite.py
/usr/local/lib/python3.6/site-packages/_pytest/compat.py:340: PytestDeprecationWarning: The TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.
See https://docs.pytest.org/en/stable/deprecations.html#terminalreporter-writer for more information.
  return getattr(object, name, default)
================================================== test session starts ===================================================
platform linux -- Python 3.6.8, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /nzscratch/shabz/nzalchemy/sqlalchemy-netezza, configfile: setup.cfg
collected 336 items

test/test_suite.py::AutocommitTest_nzdbapi+netezza_11_2_2::test_autocommit_off PASSED                              [  0%]
test/test_suite.py::AutocommitTest_nzdbapi+netezza_11_2_2::test_autocommit_on PASSED                               [  0%]
test/test_suite.py::AutocommitTest_nzdbapi+netezza_11_2_2::test_turn_autocommit_off_via_default_iso_level PASSED   [  0%]
test/test_suite.py::BooleanTest_nzdbapi+netezza_11_2_2::test_null PASSED                                           [  1%]
test/test_suite.py::BooleanTest_nzdbapi+netezza_11_2_2::test_render_literal_bool PASSED                            [  1%]
test/test_suite.py::BooleanTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                                     [  1%]
test/test_suite.py::BooleanTest_nzdbapi+netezza_11_2_2::test_whereclause PASSED                                    [  2%]
test/test_suite.py::CTETest::test_delete_from_round_trip SKIPPED                                                   [  2%]
test/test_suite.py::CTETest::test_delete_scalar_subq_round_trip SKIPPED                                            [  2%]
test/test_suite.py::CTETest::test_insert_from_select_round_trip SKIPPED                                            [  2%]
test/test_suite.py::CTETest::test_select_nonrecursive_round_trip SKIPPED                                           [  3%]
test/test_suite.py::CTETest::test_select_recursive_round_trip SKIPPED                                              [  3%]
test/test_suite.py::CTETest::test_update_from_round_trip SKIPPED                                                   [  3%]
test/test_suite.py::CollateTest_nzdbapi+netezza_11_2_2::test_collate_order_by SKIPPED                              [  4%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_autoincrement_col PASSED                  [  4%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_deprecated_get_primary_keys PASSED        [  4%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_dialect_initialize PASSED                 [  5%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_check_constraints SKIPPED             [  5%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_check_constraints_schema SKIPPED      [  5%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_columns PASSED                        [  5%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_columns_with_schema PASSED            [  6%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_comments PASSED                       [  6%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_comments_with_schema PASSED           [  6%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_default_schema_name PASSED            [  7%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_foreign_key_options_ondelete SKIPPED  [  7%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_foreign_key_options_onupdate SKIPPED  [  7%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_foreign_keys PASSED                   [  8%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_foreign_keys_with_schema PASSED       [  8%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_indexes SKIPPED                       [  8%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_indexes_with_schema SKIPPED           [  8%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_inter_schema_foreign_keys SKIPPED     [  9%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_noncol_index_no_pk SKIPPED            [  9%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_noncol_index_pk SKIPPED               [  9%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_pk_constraint PASSED                  [ 10%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_pk_constraint_with_schema PASSED      [ 10%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_schema_names PASSED                   [ 10%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_table_names PASSED                    [ 11%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_table_names_fks PASSED                [ 11%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_table_names_with_schema PASSED        [ 11%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_table_oid SKIPPED                     [ 11%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_table_oid_with_schema SKIPPED         [ 12%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_tables_and_views PASSED               [ 12%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_temp_table_columns PASSED             [ 12%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_temp_table_indexes SKIPPED            [ 13%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_temp_table_names PASSED               [ 13%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_temp_table_unique_constraints PASSED  [ 13%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_temp_view_columns SKIPPED             [ 13%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_temp_view_names SKIPPED               [ 14%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_unique_constraints PASSED             [ 14%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_unique_constraints_with_schema PASSED [ 14%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_view_columns PASSED                   [ 15%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_view_columns_with_schema PASSED       [ 15%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_view_definition PASSED                [ 15%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_view_definition_with_schema PASSED    [ 16%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_view_names PASSED                     [ 16%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_get_view_names_with_schema PASSED         [ 16%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_nullable_reflection PASSED                [ 16%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_numeric_reflection PASSED                 [ 17%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_reflect_expression_based_indexes SKIPPED  [ 17%]
test/test_suite.py::ComponentReflectionTest_nzdbapi+netezza_11_2_2::test_varchar_reflection PASSED                 [ 17%]
test/test_suite.py::CompositeKeyReflectionTest_nzdbapi+netezza_11_2_2::test_fk_column_order SKIPPED                [ 18%]
test/test_suite.py::CompositeKeyReflectionTest_nzdbapi+netezza_11_2_2::test_pk_column_order SKIPPED                [ 18%]
test/test_suite.py::CompoundSelectTest_nzdbapi+netezza_11_2_2::test_distinct_selectable_in_unions PASSED           [ 18%]
test/test_suite.py::CompoundSelectTest_nzdbapi+netezza_11_2_2::test_limit_offset_aliased_selectable_in_unions PASSED [ 19%]
test/test_suite.py::CompoundSelectTest_nzdbapi+netezza_11_2_2::test_limit_offset_in_unions_from_alias PASSED       [ 19%]
test/test_suite.py::CompoundSelectTest_nzdbapi+netezza_11_2_2::test_limit_offset_selectable_in_unions PASSED       [ 19%]
test/test_suite.py::CompoundSelectTest_nzdbapi+netezza_11_2_2::test_order_by_selectable_in_unions PASSED           [ 19%]
test/test_suite.py::CompoundSelectTest_nzdbapi+netezza_11_2_2::test_plain_union PASSED                             [ 20%]
test/test_suite.py::CompoundSelectTest_nzdbapi+netezza_11_2_2::test_select_from_plain_union PASSED                 [ 20%]
test/test_suite.py::ComputedColumnTest::test_select_all SKIPPED                                                    [ 20%]
test/test_suite.py::ComputedColumnTest::test_select_columns SKIPPED                                                [ 21%]
test/test_suite.py::ComputedReflectionTest::test_computed_col_default_not_set SKIPPED                              [ 21%]
test/test_suite.py::ComputedReflectionTest::test_get_column_returns_computed SKIPPED                               [ 21%]
test/test_suite.py::ComputedReflectionTest::test_get_column_returns_persisted SKIPPED                              [ 22%]
test/test_suite.py::ComputedReflectionTest::test_get_column_returns_persisted_with_schema SKIPPED                  [ 22%]
test/test_suite.py::DateHistoricTest_nzdbapi+netezza_11_2_2::test_literal SKIPPED                                  [ 22%]
test/test_suite.py::DateHistoricTest_nzdbapi+netezza_11_2_2::test_null PASSED                                      [ 22%]
test/test_suite.py::DateHistoricTest_nzdbapi+netezza_11_2_2::test_null_bound_comparison PASSED                     [ 23%]
test/test_suite.py::DateHistoricTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                                [ 23%]
test/test_suite.py::DateTest_nzdbapi+netezza_11_2_2::test_literal SKIPPED                                          [ 23%]
test/test_suite.py::DateTest_nzdbapi+netezza_11_2_2::test_null PASSED                                              [ 24%]
test/test_suite.py::DateTest_nzdbapi+netezza_11_2_2::test_null_bound_comparison PASSED                             [ 24%]
test/test_suite.py::DateTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                                        [ 24%]
test/test_suite.py::DateTimeCoercedToDateTimeTest_nzdbapi+netezza_11_2_2::test_literal SKIPPED                     [ 25%]
test/test_suite.py::DateTimeCoercedToDateTimeTest_nzdbapi+netezza_11_2_2::test_null PASSED                         [ 25%]
test/test_suite.py::DateTimeCoercedToDateTimeTest_nzdbapi+netezza_11_2_2::test_null_bound_comparison PASSED        [ 25%]
test/test_suite.py::DateTimeCoercedToDateTimeTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                   [ 25%]
test/test_suite.py::DateTimeHistoricTest_nzdbapi+netezza_11_2_2::test_literal SKIPPED                              [ 26%]
test/test_suite.py::DateTimeHistoricTest_nzdbapi+netezza_11_2_2::test_null PASSED                                  [ 26%]
test/test_suite.py::DateTimeHistoricTest_nzdbapi+netezza_11_2_2::test_null_bound_comparison PASSED                 [ 26%]
test/test_suite.py::DateTimeHistoricTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                            [ 27%]
test/test_suite.py::DateTimeMicrosecondsTest_nzdbapi+netezza_11_2_2::test_literal SKIPPED                          [ 27%]
test/test_suite.py::DateTimeMicrosecondsTest_nzdbapi+netezza_11_2_2::test_null PASSED                              [ 27%]
test/test_suite.py::DateTimeMicrosecondsTest_nzdbapi+netezza_11_2_2::test_null_bound_comparison PASSED             [ 27%]
test/test_suite.py::DateTimeMicrosecondsTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                        [ 28%]
test/test_suite.py::DateTimeTest_nzdbapi+netezza_11_2_2::test_literal SKIPPED                                      [ 28%]
test/test_suite.py::DateTimeTest_nzdbapi+netezza_11_2_2::test_null PASSED                                          [ 28%]
test/test_suite.py::DateTimeTest_nzdbapi+netezza_11_2_2::test_null_bound_comparison PASSED                         [ 29%]
test/test_suite.py::DateTimeTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                                    [ 29%]
test/test_suite.py::EscapingTest::test_percent_sign_round_trip PASSED                                              [ 29%]
test/test_suite.py::ExceptionTest_nzdbapi+netezza_11_2_2::test_exception_with_non_ascii PASSED                     [ 30%]
test/test_suite.py::ExceptionTest_nzdbapi+netezza_11_2_2::test_integrity_error SKIPPED                             [ 30%]
test/test_suite.py::ExistsTest_nzdbapi+netezza_11_2_2::test_select_exists PASSED                                   [ 30%]
test/test_suite.py::ExistsTest_nzdbapi+netezza_11_2_2::test_select_exists_false PASSED                             [ 30%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_bound_in_heterogeneous_two_tuple SKIPPED     [ 31%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_bound_in_scalar PASSED                       [ 31%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_bound_in_two_tuple SKIPPED                   [ 31%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_empty_heterogeneous_tuples SKIPPED           [ 32%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_empty_homogeneous_tuples SKIPPED             [ 32%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_empty_set_against_integer PASSED             [ 32%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_empty_set_against_integer_negation PASSED    [ 33%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_empty_set_against_string PASSED              [ 33%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_empty_set_against_string_negation PASSED     [ 33%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_multiple_empty_sets PASSED                   [ 33%]
test/test_suite.py::ExpandingBoundInTest_nzdbapi+netezza_11_2_2::test_null_in_empty_set_is_false PASSED            [ 34%]
test/test_suite.py::HasSequenceTest_nzdbapi+netezza_11_2_2::test_has_sequence PASSED                               [ 34%]
test/test_suite.py::HasSequenceTest_nzdbapi+netezza_11_2_2::test_has_sequence_default_not_in_remote PASSED         [ 34%]
test/test_suite.py::HasSequenceTest_nzdbapi+netezza_11_2_2::test_has_sequence_neg PASSED                           [ 35%]
test/test_suite.py::HasSequenceTest_nzdbapi+netezza_11_2_2::test_has_sequence_remote_not_in_default PASSED         [ 35%]
test/test_suite.py::HasSequenceTest_nzdbapi+netezza_11_2_2::test_has_sequence_schema PASSED                        [ 35%]
test/test_suite.py::HasSequenceTest_nzdbapi+netezza_11_2_2::test_has_sequence_schemas_neg PASSED                   [ 36%]
test/test_suite.py::HasTableTest_nzdbapi+netezza_11_2_2::test_has_table PASSED                                     [ 36%]
test/test_suite.py::HasTableTest_nzdbapi+netezza_11_2_2::test_has_table_schema PASSED                              [ 36%]
test/test_suite.py::InsertBehaviorTest_nzdbapi+netezza_11_2_2::test_autoclose_on_insert PASSED                     [ 36%]
test/test_suite.py::InsertBehaviorTest_nzdbapi+netezza_11_2_2::test_autoclose_on_insert_implicit_returning SKIPPED [ 37%]
test/test_suite.py::InsertBehaviorTest_nzdbapi+netezza_11_2_2::test_empty_insert PASSED                            [ 37%]
test/test_suite.py::InsertBehaviorTest_nzdbapi+netezza_11_2_2::test_insert_from_select PASSED                      [ 37%]
test/test_suite.py::InsertBehaviorTest_nzdbapi+netezza_11_2_2::test_insert_from_select_autoinc PASSED              [ 38%]
test/test_suite.py::InsertBehaviorTest_nzdbapi+netezza_11_2_2::test_insert_from_select_autoinc_no_rows PASSED      [ 38%]
test/test_suite.py::InsertBehaviorTest_nzdbapi+netezza_11_2_2::test_insert_from_select_with_defaults PASSED        [ 38%]
test/test_suite.py::IntegerTest_nzdbapi+netezza_11_2_2::test_huge_int PASSED                                       [ 38%]
test/test_suite.py::IntegerTest_nzdbapi+netezza_11_2_2::test_literal PASSED                                        [ 39%]
test/test_suite.py::IsOrIsNotDistinctFromTest_nzdbapi+netezza_11_2_2::test_is_or_isnot_distinc SKIPPED             [ 39%]
test/test_suite.py::IsOrIsNotDistinctFromTest_nzdbapi+netezza_11_2_2::test_is_or_isnot_distinct_from SKIPPED       [ 39%]
test/test_suite.py::IsolationLevelTest::test_all_levels SKIPPED                                                    [ 40%]
test/test_suite.py::IsolationLevelTest::test_default_isolation_level SKIPPED                                       [ 40%]
test/test_suite.py::IsolationLevelTest::test_non_default_isolation_level SKIPPED                                   [ 40%]
test/test_suite.py::JSONStringCastIndexTest::test_crit_against_int_basic SKIPPED                                   [ 41%]
test/test_suite.py::JSONStringCastIndexTest::test_crit_against_int_coerce_type SKIPPED                             [ 41%]
test/test_suite.py::JSONStringCastIndexTest::test_crit_against_string_coerce_type SKIPPED                          [ 41%]
test/test_suite.py::JSONStringCastIndexTest::test_string_cast_crit_against_string_basic SKIPPED                    [ 41%]
test/test_suite.py::JSONStringCastIndexTest::test_string_cast_crit_mixed_path SKIPPED                              [ 42%]
test/test_suite.py::JSONStringCastIndexTest::test_string_cast_crit_simple_int SKIPPED                              [ 42%]
test/test_suite.py::JSONStringCastIndexTest::test_string_cast_crit_spaces_in_key SKIPPED                           [ 42%]
test/test_suite.py::JSONStringCastIndexTest::test_string_cast_crit_string_path SKIPPED                             [ 43%]
test/test_suite.py::JSONTest::test_eval_none_flag_orm SKIPPED                                                      [ 43%]
test/test_suite.py::JSONTest::test_index_typed_access[boolean0] SKIPPED                                            [ 43%]
test/test_suite.py::JSONTest::test_index_typed_access[boolean1] SKIPPED                                            [ 44%]
test/test_suite.py::JSONTest::test_index_typed_access[boolean2] SKIPPED                                            [ 44%]
test/test_suite.py::JSONTest::test_index_typed_access[float0] SKIPPED                                              [ 44%]
test/test_suite.py::JSONTest::test_index_typed_access[float1] SKIPPED                                              [ 44%]
test/test_suite.py::JSONTest::test_index_typed_access[integer0] SKIPPED                                            [ 45%]
test/test_suite.py::JSONTest::test_index_typed_access[integer1] SKIPPED                                            [ 45%]
test/test_suite.py::JSONTest::test_index_typed_access[integer2] SKIPPED                                            [ 45%]
test/test_suite.py::JSONTest::test_index_typed_access[integer3] SKIPPED                                            [ 46%]
test/test_suite.py::JSONTest::test_index_typed_access[string0] SKIPPED                                             [ 46%]
test/test_suite.py::JSONTest::test_index_typed_access[string1] SKIPPED                                             [ 46%]
test/test_suite.py::JSONTest::test_index_typed_access[string2] SKIPPED                                             [ 47%]
test/test_suite.py::JSONTest::test_index_typed_access[string3] SKIPPED                                             [ 47%]
test/test_suite.py::JSONTest::test_index_typed_comparison[boolean0] SKIPPED                                        [ 47%]
test/test_suite.py::JSONTest::test_index_typed_comparison[boolean1] SKIPPED                                        [ 47%]
test/test_suite.py::JSONTest::test_index_typed_comparison[boolean2] SKIPPED                                        [ 48%]
test/test_suite.py::JSONTest::test_index_typed_comparison[float0] SKIPPED                                          [ 48%]
test/test_suite.py::JSONTest::test_index_typed_comparison[float1] SKIPPED                                          [ 48%]
test/test_suite.py::JSONTest::test_index_typed_comparison[integer0] SKIPPED                                        [ 49%]
test/test_suite.py::JSONTest::test_index_typed_comparison[integer1] SKIPPED                                        [ 49%]
test/test_suite.py::JSONTest::test_index_typed_comparison[integer2] SKIPPED                                        [ 49%]
test/test_suite.py::JSONTest::test_index_typed_comparison[integer3] SKIPPED                                        [ 50%]
test/test_suite.py::JSONTest::test_index_typed_comparison[string0] SKIPPED                                         [ 50%]
test/test_suite.py::JSONTest::test_index_typed_comparison[string1] SKIPPED                                         [ 50%]
test/test_suite.py::JSONTest::test_index_typed_comparison[string2] SKIPPED                                         [ 50%]
test/test_suite.py::JSONTest::test_index_typed_comparison[string3] SKIPPED                                         [ 51%]
test/test_suite.py::JSONTest::test_path_typed_comparison[boolean0] SKIPPED                                         [ 51%]
test/test_suite.py::JSONTest::test_path_typed_comparison[boolean1] SKIPPED                                         [ 51%]
test/test_suite.py::JSONTest::test_path_typed_comparison[boolean2] SKIPPED                                         [ 52%]
test/test_suite.py::JSONTest::test_path_typed_comparison[float0] SKIPPED                                           [ 52%]
test/test_suite.py::JSONTest::test_path_typed_comparison[float1] SKIPPED                                           [ 52%]
test/test_suite.py::JSONTest::test_path_typed_comparison[integer0] SKIPPED                                         [ 52%]
test/test_suite.py::JSONTest::test_path_typed_comparison[integer1] SKIPPED                                         [ 53%]
test/test_suite.py::JSONTest::test_path_typed_comparison[integer2] SKIPPED                                         [ 53%]
test/test_suite.py::JSONTest::test_path_typed_comparison[integer3] SKIPPED                                         [ 53%]
test/test_suite.py::JSONTest::test_path_typed_comparison[string0] SKIPPED                                          [ 54%]
test/test_suite.py::JSONTest::test_path_typed_comparison[string1] SKIPPED                                          [ 54%]
test/test_suite.py::JSONTest::test_path_typed_comparison[string2] SKIPPED                                          [ 54%]
test/test_suite.py::JSONTest::test_path_typed_comparison[string3] SKIPPED                                          [ 55%]
test/test_suite.py::JSONTest::test_round_trip_custom_json SKIPPED                                                  [ 55%]
test/test_suite.py::JSONTest::test_round_trip_data1 SKIPPED                                                        [ 55%]
test/test_suite.py::JSONTest::test_round_trip_json_null_as_json_null SKIPPED                                       [ 55%]
test/test_suite.py::JSONTest::test_round_trip_none_as_json_null SKIPPED                                            [ 56%]
test/test_suite.py::JSONTest::test_round_trip_none_as_sql_null SKIPPED                                             [ 56%]
test/test_suite.py::JSONTest::test_single_element_round_trip[-1.0] SKIPPED                                         [ 56%]
test/test_suite.py::JSONTest::test_single_element_round_trip[-1] SKIPPED                                           [ 57%]
test/test_suite.py::JSONTest::test_single_element_round_trip[0] SKIPPED                                            [ 57%]
test/test_suite.py::JSONTest::test_single_element_round_trip[15.052] SKIPPED                                       [ 57%]
test/test_suite.py::JSONTest::test_single_element_round_trip[15] SKIPPED                                           [ 58%]
test/test_suite.py::JSONTest::test_single_element_round_trip[False] SKIPPED                                        [ 58%]
test/test_suite.py::JSONTest::test_single_element_round_trip[None] SKIPPED                                         [ 58%]
test/test_suite.py::JSONTest::test_single_element_round_trip[True] SKIPPED                                         [ 58%]
test/test_suite.py::JSONTest::test_single_element_round_trip[a string] SKIPPED                                     [ 59%]
test/test_suite.py::JSONTest::test_single_element_round_trip[r\xe9ve ill\xe9] SKIPPED                              [ 59%]
test/test_suite.py::JSONTest::test_single_element_round_trip[r\xe9ve\U0001f40d ill\xe9] SKIPPED                    [ 59%]
test/test_suite.py::JSONTest::test_unicode_round_trip SKIPPED                                                      [ 60%]
test/test_suite.py::LastrowidTest_nzdbapi+netezza_11_2_2::test_autoincrement_on_insert PASSED                      [ 60%]
test/test_suite.py::LastrowidTest_nzdbapi+netezza_11_2_2::test_last_inserted_id PASSED                             [ 60%]
test/test_suite.py::LastrowidTest_nzdbapi+netezza_11_2_2::test_native_lastrowid_autoinc SKIPPED                    [ 61%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_contains_autoescape PASSED                      [ 61%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_contains_autoescape_escape PASSED               [ 61%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_contains_escape PASSED                          [ 61%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_contains_unescaped PASSED                       [ 62%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_endswith_autoescape PASSED                      [ 62%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_endswith_autoescape_escape PASSED               [ 62%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_endswith_escape PASSED                          [ 63%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_endswith_sqlexpr PASSED                         [ 63%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_endswith_unescaped PASSED                       [ 63%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_startswith_autoescape PASSED                    [ 63%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_startswith_autoescape_escape PASSED             [ 64%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_startswith_escape PASSED                        [ 64%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_startswith_sqlexpr PASSED                       [ 64%]
test/test_suite.py::LikeFunctionsTest_nzdbapi+netezza_11_2_2::test_startswith_unescaped PASSED                     [ 65%]
test/test_suite.py::LimitOffsetTest_nzdbapi+netezza_11_2_2::test_bound_limit SKIPPED                               [ 65%]
test/test_suite.py::LimitOffsetTest_nzdbapi+netezza_11_2_2::test_bound_limit_offset SKIPPED                        [ 65%]
test/test_suite.py::LimitOffsetTest_nzdbapi+netezza_11_2_2::test_bound_offset SKIPPED                              [ 66%]
test/test_suite.py::LimitOffsetTest_nzdbapi+netezza_11_2_2::test_limit_offset_nobinds PASSED                       [ 66%]
test/test_suite.py::LimitOffsetTest_nzdbapi+netezza_11_2_2::test_simple_limit PASSED                               [ 66%]
test/test_suite.py::LimitOffsetTest_nzdbapi+netezza_11_2_2::test_simple_limit_offset PASSED                        [ 66%]
test/test_suite.py::LimitOffsetTest_nzdbapi+netezza_11_2_2::test_simple_offset PASSED                              [ 67%]
test/test_suite.py::NormalizedNameTest::test_get_table_names SKIPPED                                               [ 67%]
test/test_suite.py::NormalizedNameTest::test_reflect_lowercase_forced_tables SKIPPED                               [ 67%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_decimal_coerce_round_trip SKIPPED                     [ 68%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_decimal_coerce_round_trip_w_cast PASSED               [ 68%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_enotation_decimal PASSED                              [ 68%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_enotation_decimal_large PASSED                        [ 69%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_float_as_decimal PASSED                               [ 69%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_float_as_float PASSED                                 [ 69%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_float_coerce_round_trip PASSED                        [ 69%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_float_custom_scale PASSED                             [ 70%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_many_significant_digits SKIPPED                       [ 70%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_numeric_as_decimal PASSED                             [ 70%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_numeric_as_float PASSED                               [ 71%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_numeric_no_decimal PASSED                             [ 71%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_numeric_null_as_decimal FAILED                        [ 71%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_numeric_null_as_float PASSED                          [ 72%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_precision_decimal PASSED                              [ 72%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_render_literal_float PASSED                           [ 72%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_render_literal_numeric PASSED                         [ 72%]
test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_render_literal_numeric_asfloat PASSED                 [ 73%]
test/test_suite.py::OrderByLabelTest_nzdbapi+netezza_11_2_2::test_composed_int PASSED                              [ 73%]
test/test_suite.py::OrderByLabelTest_nzdbapi+netezza_11_2_2::test_composed_int_desc PASSED                         [ 73%]
test/test_suite.py::OrderByLabelTest_nzdbapi+netezza_11_2_2::test_composed_multiple PASSED                         [ 74%]
test/test_suite.py::OrderByLabelTest_nzdbapi+netezza_11_2_2::test_group_by_composed PASSED                         [ 74%]
test/test_suite.py::OrderByLabelTest_nzdbapi+netezza_11_2_2::test_plain PASSED                                     [ 74%]
test/test_suite.py::OrderByLabelTest_nzdbapi+netezza_11_2_2::test_plain_desc PASSED                                [ 75%]
test/test_suite.py::PercentSchemaNamesTest_nzdbapi+netezza_11_2_2::test_executemany_roundtrip PASSED               [ 75%]
test/test_suite.py::PercentSchemaNamesTest_nzdbapi+netezza_11_2_2::test_single_roundtrip PASSED                    [ 75%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_check_constraints SKIPPED              [ 75%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_columns SKIPPED                        [ 76%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_foreign_keys SKIPPED                   [ 76%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_indexes SKIPPED                        [ 76%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_pk_constraint SKIPPED                  [ 77%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_table_comment SKIPPED                  [ 77%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_table_options SKIPPED                  [ 77%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_unique_constraints SKIPPED             [ 77%]
test/test_suite.py::QuotedNameArgumentTest_nzdbapi+netezza_11_2_2::test_get_view_definition SKIPPED                [ 78%]
test/test_suite.py::ReturningTest::test_autoincrement_on_insert_implicit_returning SKIPPED                         [ 78%]
test/test_suite.py::ReturningTest::test_explicit_returning_pk_autocommit SKIPPED                                   [ 78%]
test/test_suite.py::ReturningTest::test_explicit_returning_pk_no_autocommit SKIPPED                                [ 79%]
test/test_suite.py::ReturningTest::test_last_inserted_id_implicit_returning SKIPPED                                [ 79%]
test/test_suite.py::RowFetchTest_nzdbapi+netezza_11_2_2::test_row_w_scalar_select PASSED                           [ 79%]
test/test_suite.py::RowFetchTest_nzdbapi+netezza_11_2_2::test_row_with_dupe_names PASSED                           [ 80%]
test/test_suite.py::RowFetchTest_nzdbapi+netezza_11_2_2::test_via_col_object PASSED                                [ 80%]
test/test_suite.py::RowFetchTest_nzdbapi+netezza_11_2_2::test_via_int PASSED                                       [ 80%]
test/test_suite.py::RowFetchTest_nzdbapi+netezza_11_2_2::test_via_string PASSED                                    [ 80%]
test/test_suite.py::SequenceCompilerTest_nzdbapi+netezza_11_2_2::test_literal_binds_inline_compile PASSED          [ 81%]
test/test_suite.py::SequenceTest_nzdbapi+netezza_11_2_2::test_insert_lastrowid PASSED                              [ 81%]
test/test_suite.py::SequenceTest_nzdbapi+netezza_11_2_2::test_insert_roundtrip PASSED                              [ 81%]
test/test_suite.py::SequenceTest_nzdbapi+netezza_11_2_2::test_nextval_direct PASSED                                [ 82%]
test/test_suite.py::SequenceTest_nzdbapi+netezza_11_2_2::test_optional_seq PASSED                                  [ 82%]
test/test_suite.py::ServerSideCursorsTest::test_aliases_and_ss SKIPPED                                             [ 82%]
test/test_suite.py::ServerSideCursorsTest::test_conn_option SKIPPED                                                [ 83%]
test/test_suite.py::ServerSideCursorsTest::test_roundtrip SKIPPED                                                  [ 83%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[for_update_expr] SKIPPED                          [ 83%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[for_update_string] SKIPPED                        [ 83%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[global_expr] SKIPPED                              [ 84%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[global_off_explicit] SKIPPED                      [ 84%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[global_string] SKIPPED                            [ 84%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[global_text] SKIPPED                              [ 85%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[stmt_option] SKIPPED                              [ 85%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[stmt_option_disabled] SKIPPED                     [ 85%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[text_no_ss] SKIPPED                               [ 86%]
test/test_suite.py::ServerSideCursorsTest::test_ss_cursor_status[text_ss_option] SKIPPED                           [ 86%]
test/test_suite.py::ServerSideCursorsTest::test_stmt_enabled_conn_option_disabled SKIPPED                          [ 86%]
test/test_suite.py::SimpleUpdateDeleteTest_nzdbapi+netezza_11_2_2::test_delete PASSED                              [ 86%]
test/test_suite.py::SimpleUpdateDeleteTest_nzdbapi+netezza_11_2_2::test_update PASSED                              [ 87%]
test/test_suite.py::StringTest_nzdbapi+netezza_11_2_2::test_literal PASSED                                         [ 87%]
test/test_suite.py::StringTest_nzdbapi+netezza_11_2_2::test_literal_backslashes PASSED                             [ 87%]
test/test_suite.py::StringTest_nzdbapi+netezza_11_2_2::test_literal_non_ascii PASSED                               [ 88%]
test/test_suite.py::StringTest_nzdbapi+netezza_11_2_2::test_literal_quoting PASSED                                 [ 88%]
test/test_suite.py::StringTest_nzdbapi+netezza_11_2_2::test_nolength_string SKIPPED                                [ 88%]
test/test_suite.py::TableDDLTest_nzdbapi+netezza_11_2_2::test_add_table_comment PASSED                             [ 88%]
test/test_suite.py::TableDDLTest_nzdbapi+netezza_11_2_2::test_create_table PASSED                                  [ 89%]
test/test_suite.py::TableDDLTest_nzdbapi+netezza_11_2_2::test_create_table_schema PASSED                           [ 89%]
test/test_suite.py::TableDDLTest_nzdbapi+netezza_11_2_2::test_drop_table PASSED                                    [ 89%]
test/test_suite.py::TableDDLTest_nzdbapi+netezza_11_2_2::test_drop_table_comment PASSED                            [ 90%]
test/test_suite.py::TableDDLTest_nzdbapi+netezza_11_2_2::test_underscore_names SKIPPED                             [ 90%]
test/test_suite.py::TextTest::test_literal SKIPPED                                                                 [ 90%]
test/test_suite.py::TextTest::test_literal_backslashes SKIPPED                                                     [ 91%]
test/test_suite.py::TextTest::test_literal_non_ascii SKIPPED                                                       [ 91%]
test/test_suite.py::TextTest::test_literal_percentsigns SKIPPED                                                    [ 91%]
test/test_suite.py::TextTest::test_literal_quoting SKIPPED                                                         [ 91%]
test/test_suite.py::TextTest::test_text_empty_strings SKIPPED                                                      [ 92%]
test/test_suite.py::TextTest::test_text_null_strings SKIPPED                                                       [ 92%]
test/test_suite.py::TextTest::test_text_roundtrip SKIPPED                                                          [ 92%]
test/test_suite.py::TimeMicrosecondsTest::test_literal SKIPPED                                                     [ 93%]
test/test_suite.py::TimeMicrosecondsTest::test_null SKIPPED                                                        [ 93%]
test/test_suite.py::TimeMicrosecondsTest::test_null_bound_comparison SKIPPED                                       [ 93%]
test/test_suite.py::TimeMicrosecondsTest::test_round_trip SKIPPED                                                  [ 94%]
test/test_suite.py::TimeTest_nzdbapi+netezza_11_2_2::test_literal SKIPPED                                          [ 94%]
test/test_suite.py::TimeTest_nzdbapi+netezza_11_2_2::test_null PASSED                                              [ 94%]
test/test_suite.py::TimeTest_nzdbapi+netezza_11_2_2::test_null_bound_comparison PASSED                             [ 94%]
test/test_suite.py::TimeTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                                        [ 95%]
test/test_suite.py::TimestampMicrosecondsTest_nzdbapi+netezza_11_2_2::test_literal SKIPPED                         [ 95%]
test/test_suite.py::TimestampMicrosecondsTest_nzdbapi+netezza_11_2_2::test_null PASSED                             [ 95%]
test/test_suite.py::TimestampMicrosecondsTest_nzdbapi+netezza_11_2_2::test_null_bound_comparison PASSED            [ 96%]
test/test_suite.py::TimestampMicrosecondsTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                       [ 96%]
test/test_suite.py::UnicodeTextTest::test_empty_strings_text SKIPPED                                               [ 96%]
test/test_suite.py::UnicodeTextTest::test_literal SKIPPED                                                          [ 97%]
test/test_suite.py::UnicodeTextTest::test_literal_non_ascii SKIPPED                                                [ 97%]
test/test_suite.py::UnicodeTextTest::test_null_strings_text SKIPPED                                                [ 97%]
test/test_suite.py::UnicodeTextTest::test_round_trip SKIPPED                                                       [ 97%]
test/test_suite.py::UnicodeTextTest::test_round_trip_executemany SKIPPED                                           [ 98%]
test/test_suite.py::UnicodeVarcharTest_nzdbapi+netezza_11_2_2::test_empty_strings_varchar PASSED                   [ 98%]
test/test_suite.py::UnicodeVarcharTest_nzdbapi+netezza_11_2_2::test_literal PASSED                                 [ 98%]
test/test_suite.py::UnicodeVarcharTest_nzdbapi+netezza_11_2_2::test_literal_non_ascii PASSED                       [ 99%]
test/test_suite.py::UnicodeVarcharTest_nzdbapi+netezza_11_2_2::test_null_strings_varchar PASSED                    [ 99%]
test/test_suite.py::UnicodeVarcharTest_nzdbapi+netezza_11_2_2::test_round_trip PASSED                              [ 99%]
test/test_suite.py::UnicodeVarcharTest_nzdbapi+netezza_11_2_2::test_round_trip_executemany PASSED                  [100%]

================================================ short test summary info =================================================
FAILED test/test_suite.py::NumericTest_nzdbapi+netezza_11_2_2::test_numeric_null_as_decimal - TypeError: conversion fro...
================================= 1 failed, 166 passed, 169 skipped in 114.14s (0:01:54) =================================

```