### PR TITLE
Remove pyodbc and nzpy install dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ nzalchemy runs on top of pyodbc(over nzodbc) or nzpy as a dialect to bridge Nete
 ## Prerequisites for using nzalchemy with pyodbc
 
 **Install pyodbc Python package**
+Details of pyodbc pre-requisites and installation instruction can be found here: https://github.com/mkleehammer/pyodbc/wiki/Install 
 
 **Install Netezza OBDC(nzodbc) drivers**
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ nzalchemy runs on top of pyodbc(over nzodbc) or nzpy as a dialect to bridge Nete
 ## Prerequisites for using nzalchemy with pyodbc
 
 **Install pyodbc Python package**
+
 Details of pyodbc pre-requisites and installation instruction can be found here: https://github.com/mkleehammer/pyodbc/wiki/Install 
 
 **Install Netezza OBDC(nzodbc) drivers**

--- a/sqlalchemy-netezza/setup.py
+++ b/sqlalchemy-netezza/setup.py
@@ -39,7 +39,7 @@ setup(
     },
     packages=find_packages(include=["nzalchemy"]),
     include_package_data=True,
-    install_requires=["SQLAlchemy<=1.3.24", "pyodbc>=4.0.27","nzpy"],
+    install_requires=["SQLAlchemy<=1.3.24"],
     zip_safe=False,
     entry_points={
         "sqlalchemy.dialects": [

--- a/sqlalchemy-netezza/setup.py
+++ b/sqlalchemy-netezza/setup.py
@@ -39,7 +39,7 @@ setup(
     },
     packages=find_packages(include=["nzalchemy"]),
     include_package_data=True,
-    install_requires=["SQLAlchemy<=1.3.24"],
+    install_requires=["SQLAlchemy<=1.3.24", "nzpy"],
     zip_safe=False,
     entry_points={
         "sqlalchemy.dialects": [


### PR DESCRIPTION
Problem: nzalchemy installation has dependency on pyodbc and nzpy. Some user may want to use nzalchemy with nzpy so they do not need pyodbc installation.

Solution: Remove nzalchemy installation dependency from pyodbc and nzpy

Testing:  pip install nzalchemy 

Before the changes: 
```
[nz@sim-ips26 nzalchemy]$ pip3 install nzalchemy
Requirement already satisfied: nzalchemy in /usr/local/lib/python3.6/site-packages
Requirement already satisfied: pyodbc>=4.0.27 in /usr/local/lib64/python3.6/site-packages (from nzalchemy)
Requirement already satisfied: nzpy in /usr/local/lib/python3.6/site-packages (from nzalchemy)
Requirement already satisfied: SQLAlchemy<=1.3.24 in /usr/local/lib64/python3.6/site-packages (from nzalchemy)
Requirement already satisfied: scramp==1.1.0 in /usr/local/lib/python3.6/site-packages (from nzpy->nzalchemy)

```

After :
```
[nz@sim-ips26 sqlalchemy-netezza]$ pip3 install nzalchemy
Requirement already satisfied: nzalchemy in /usr/local/lib/python3.6/site-packages/nzalchemy-11.0.0-py3.6.egg
Requirement already satisfied: SQLAlchemy<=1.3.24 in /usr/local/lib64/python3.6/site-packages (from nzalchemy)

```